### PR TITLE
Fixes memory leak caused by mediator and command instances being held by...

### DIFF
--- a/src/mmvc/base/CommandMap.hx
+++ b/src/mmvc/base/CommandMap.hx
@@ -141,6 +141,7 @@ class CommandMap implements ICommandMap
 		injector.unmap(AnySignal);
 		unmapSignalValues(signal.valueClasses, valueObjects);
 		command.execute();
+		injector.attendedToInjectees.delete(command);
 		
 		if (oneshot)
 		{

--- a/src/mmvc/base/MediatorMap.hx
+++ b/src/mmvc/base/MediatorMap.hx
@@ -163,7 +163,9 @@ class MediatorMap extends ViewMapBase, implements IMediatorMap
 	
 	public function removeMediatorByView(viewComponent:Dynamic):IMediator
 	{
-		return removeMediator(retrieveMediator(viewComponent));
+		var mediator = removeMediator(retrieveMediator(viewComponent));
+		injector.attendedToInjectees.delete(mediator);
+		return mediator;
 	}
 	
 	public function retrieveMediator(viewComponent:Dynamic):IMediator
@@ -259,7 +261,6 @@ class MediatorMap extends ViewMapBase, implements IMediatorMap
 			{
 				removeMediatorByView(view);
 			}
-			
 			mediatorsMarkedForRemoval.delete(view);
 		}
 


### PR DESCRIPTION
... injector.attendedToInjectees

References to executed Command instances and removed Mediators were being held in injector.attendedToInjectees preventing garbage collection of those objects and other objects that they might have been referencing.

Problem observed in flash and js targets.
Flash issues may be fixed by making sure all Dictionaries use weak references.
e.g.
attendedToInjectees = new Dictionary<Dynamic, Bool>(true);

However, js target needs more explicit action to allow unused objects to be GC'd.
