### PR TITLE
Fixes #27 - Mapping mediator by qualified class name (string) fails 

### DIFF
--- a/src/mmvc/base/MediatorMap.hx
+++ b/src/mmvc/base/MediatorMap.hx
@@ -275,16 +275,22 @@ class MediatorMap extends ViewMapBase implements IMediatorMap
 
 			if (config != null)
 			{
-				for (claxx in config.typedViewClasses) 
+				if (config.typedViewClasses != null)
 				{
-					injector.mapValue(claxx, viewComponent);
+					for (claxx in config.typedViewClasses) 
+					{
+						injector.mapValue(claxx, viewComponent);
+					}
 				}
 
 				mediator = injector.instantiate(config.mediatorClass);
 
-				for (clazz in config.typedViewClasses) 
+				if (config.typedViewClasses != null)
 				{
-					injector.unmap(clazz);
+					for (clazz in config.typedViewClasses) 
+					{
+						injector.unmap(clazz);
+					}
 				}
 
 				registerMediator(viewComponent, mediator);

--- a/test/mmvc/base/MediatorMapTest.hx
+++ b/test/mmvc/base/MediatorMapTest.hx
@@ -87,6 +87,22 @@ class MediatorMapTest
 	}
 	
 	@Test
+	public function mediator_is_mapped_by_string_And_created_for_view():Void
+	{
+		mediatorMap.mapView('mmvc.impl.support.ViewComponent', ViewMediator, null, false, false);
+		
+		var viewComponent = new ViewComponent();
+		contextView.addView(viewComponent);
+		
+		var mediator = mediatorMap.createMediator(viewComponent);
+		var hasMapping = mediatorMap.hasMapping(ViewComponent);
+		
+		Assert.isTrue(hasMapping);
+		Assert.isNotNull(mediator);
+		Assert.isTrue(mediatorMap.hasMediatorForView(viewComponent));
+	}
+	
+	@Test
 	public function mediator_is_mapped_and_created_with_inject_view_as_class():Void
 	{
 		mediatorMap.mapView(ViewComponent, ViewMediator, ViewComponent, false, false);


### PR DESCRIPTION
Guard against null `typedViewClasses` references.